### PR TITLE
Fix route names 

### DIFF
--- a/resources/views/apps/edit.blade.php
+++ b/resources/views/apps/edit.blade.php
@@ -27,17 +27,17 @@
 
     <div class="card col-xs-12 mt-4">
         <div class="card-header">
-            <a class="btn btn-danger left" href="{{ route('websockets.admin.index') }}">Back</a>
+            <a class="btn btn-danger left" href="{{ route('laravel-websockets.websockets.admin.index') }}">Back</a>
         </div>
         <div class="card-body">
             @if ($app->id)
                 <h4 class="mb-4">Edit app</h4>
 
-                <form method="post" action="{{ route('websockets.admin.update', $app->id) }}">
+                <form method="post" action="{{ route('laravel-websockets.websockets.admin.update', $app->id) }}">
             @else
                 <h4 class="mb-4">Create app</h4>
 
-                <form method="post" action="{{ route('websockets.admin.store') }}">
+                <form method="post" action="{{ route('laravel-websockets.websockets.admin.store') }}">
             @endif
                 @csrf
 

--- a/resources/views/apps/index.blade.php
+++ b/resources/views/apps/index.blade.php
@@ -23,11 +23,11 @@
         <div class="card-header">
             <div class="row">
                 <div class="col-12 col-sm-6">
-                    <form method="get" action="{{ route('websockets.admin.index') }}">
+                    <form method="get" action="{{ route('laravel-websockets.websockets.admin.index') }}">
                         <div class="input-group">
                             @if (!blank(request('q')))
                                 <div class="input-group-prepend">
-                                    <a href="{{ route('websockets.admin.index') }}" class="btn btn-outline-danger">X</a>
+                                    <a href="{{ route('laravel-websockets.websockets.admin.index') }}" class="btn btn-outline-danger">X</a>
                                 </div>
                             @endif
                             <input type="text" name="q" class="form-control" placeholder="Search..." value="{{ request('q', old('q')) }}" />
@@ -38,7 +38,7 @@
                     </form>
                 </div>
                 <div class="col-12 col-sm-6 text-right">
-                    <a class="btn btn-success" href="{{ route('websockets.admin.create') }}">Create app</a>
+                    <a class="btn btn-success" href="{{ route('laravel-websockets.websockets.admin.create') }}">Create app</a>
                 </div>
             </div>
         </div>
@@ -66,8 +66,8 @@
                         <td>{{ $app->enable_client_messages ? 'YES' : "NO" }}</td>
                         <td>{{ $app->enable_statistics ? 'YES' : "NO" }}</td>
                         <td>
-                            <a class="btn btn-block btn-primary" href="{{ route('websockets.admin.edit', ['app' => $app->id]) }}">Edit</a>
-                            <form method="post" action="{{ route('websockets.admin.destroy', ['app' => $app->id]) }}" onsubmit="return(confirm('Are you sure?'))">
+                            <a class="btn btn-block btn-primary" href="{{ route('laravel-websockets.websockets.admin.edit', ['app' => $app->id]) }}">Edit</a>
+                            <form method="post" action="{{ route('laravel-websockets.websockets.admin.destroy', ['app' => $app->id]) }}" onsubmit="return(confirm('Are you sure?'))">
                                 @csrf
                                 <button type="submit" class="btn btn-block mt-1 btn-danger">Delete</button>
                             </form>

--- a/src/Database/Http/Controllers/AppsController.php
+++ b/src/Database/Http/Controllers/AppsController.php
@@ -54,7 +54,7 @@ class AppsController
         $app->enable_statistics = $request->get('enable_statistics', false);
         $app->save();
 
-        return redirect(route('websockets.admin.edit', ['app' => $app->id]))->with('success', 'Record created.');
+        return redirect(route('laravel-websockets.websockets.admin.edit', ['app' => $app->id]))->with('success', 'Record created.');
     }
 
     /**
@@ -86,7 +86,7 @@ class AppsController
         $app->enable_statistics = $request->get('enable_statistics', false);
         $app->save();
 
-        return redirect(route('websockets.admin.edit', ['app' => $app->id]))->with('success', 'Record saved.');
+        return redirect(route('laravel-websockets.websockets.admin.edit', ['app' => $app->id]))->with('success', 'Record saved.');
     }
 
     /**
@@ -99,6 +99,6 @@ class AppsController
     {
         $app->delete();
 
-        return redirect(route('websockets.admin.index'))->with('success', 'Record deleted.');
+        return redirect(route('laravel-websockets.websockets.admin.index'))->with('success', 'Record deleted.');
     }
 }


### PR DESCRIPTION
a few places in the templates + controller are using the route helper but not taking the route group `as` prefix into account 

tbh im not sure if this is a laravel version issue or just something that was missed i do feel like i remember some stuff a few years ago with laravel changing how route groups affected names 

if it does make a difference im currently using laravel framework v8.83.12